### PR TITLE
Run $precmd_functions after cd

### DIFF
--- a/formarks.plugin.zsh
+++ b/formarks.plugin.zsh
@@ -104,7 +104,12 @@ function jump() {
         wfxr::pathmarks-fzf --query="$*" -1|
         sed 's#.*->  ##')
     if [[ -d "$target" ]]; then
-        cd "$target" && zle reset-prompt
+        cd "$target" 
+        local precmd
+        for precmd in $precmd_functions; do
+            $precmd
+        done
+        zle reset-prompt
     else
         zle redisplay # Just redisplay if no jump to do
     fi


### PR DESCRIPTION
The code was taken from [fzf-marks](https://github.com/urbainvaes/fzf-marks) to allow to run $precmd_functions after changing directory via `formarks`. It fixes for me the git info at the prompt (I use [spaceship-prompt](https://github.com/denysdovhan/spaceship-prompt)).
The value of $precmd_functions at my PC is `spaceship_exec_time_precmd_hook spaceship_exec_vcs_info_precmd_hook _zsh_autosuggest_start`.
What do you think?
Thanks!